### PR TITLE
Allow parametrized calling of Dynamic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/*
+.venv

--- a/Dynamic.py
+++ b/Dynamic.py
@@ -1,3 +1,6 @@
+import sys
+
+
 def init_result():
     return {
         "model_name": {},
@@ -195,4 +198,6 @@ def dynamic(
 
 
 if __name__ == "__main__":
-    dynamic("instances/0", "dyn_out")
+    file = sys.argv[1] if len(sys.argv) > 1 else "0"
+    lastDay = int(sys.argv[2]) if len(sys.argv) > 2 else 364
+    dynamic(f"instances/{file}", "dyn_out", lastDay=lastDay)


### PR DESCRIPTION
In order to use the solver from within out student projects, it would be nice to be able to call the `Dynamic` script with some parameters. 

This PR just adds a rudimentary way of passing a filename and the last day to the script.

Calling the script with no parameters results in the current behavior.