### PR TITLE
Add helper script for calling assign_patients from django

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/*
+.venv

--- a/call_from_django.py
+++ b/call_from_django.py
@@ -1,0 +1,34 @@
+import json
+import sys
+
+from Dynamic import assign_patients
+
+
+def call_from_django(file, last_day):
+    """
+    Helper function for retrieving a patient assignment from
+    an external source, e.g. django.
+
+    :param file: filename without extension or path prefixes
+    :type file: str
+    :param last_day: last day for which to find an assignment
+    :type last_day: int
+    """
+    with open(f"{file}.json") as f:
+        input_data = json.load(f)
+
+    rooms = input_data["rooms"]
+    patients = input_data["patients"]
+    current_assignment = input_data["currentPatientAssignment"]
+
+    result = assign_patients(patients, 0, last_day, rooms, current_assignment)
+
+    with open(f"Results/{file}_out.json", "w", encoding="utf-8") as out:
+        out.write(json.dumps(result, indent=4))
+
+
+if __name__ == "__main__":
+    file = sys.argv[1] if len(sys.argv) > 1 else "0"
+    last_day = int(sys.argv[2]) if len(sys.argv) > 2 else 364
+
+    call_from_django(f"instances/{file}", last_day)


### PR DESCRIPTION
I am opening this PR to hopefully save some of the other groups some work. We're calling the helper function from this PR like this:
```bash
#!/bin/bash

cd "$1" || exit 1
source .venv/bin/activate
python call_from_django.py "$2" "$3"
```
where `$1` is the location of the cloned `patient-to-room_assignment` repository, `$2` is the solver input filename, and `$3` is the last day to solve for.
This in turned is called like this:
```python
def _call_solver(last_day):
    script = os.path.join(
        os.path.dirname(os.path.abspath(__file__)), "call_solver.sh"
    )
    with open(os.devnull, "wb") as devnull:
        subprocess.call(
            [script, settings.PRA_BASE, "generated", str(last_day)], stdout=devnull
        )
```

This is, of course, a bit of an awkward solution (python/django -> bash -> python), but the "ideal" way of just importing `patient-to-room_assignment/Dynamic.py` directly into our django projects is not feasible, because `patient-to-room_assignment` is not set up as an installable python package, and since python does not allow imports beyond the package top level, the only other ways to call code from `patient-to-room_assignment` are rather messy `sys.path` hacks.